### PR TITLE
bugfix/hide-cookie-banner

### DIFF
--- a/src/controllers/login.js
+++ b/src/controllers/login.js
@@ -48,6 +48,11 @@ const validateToken = async (session) => {
 };
 
 const loginController = async (request) => {
+  // The login page, like the start page is where our cookie banner is placed,
+  // so by progressing past this page, we know the user's seen the banner, so we
+  // don't need to show it again.
+  request.session.seenCookie = true;
+
   // First of all, check if we've already logged in.
   if (request.session.loggedInRegNo) {
     // If so, go right ahead!


### PR DESCRIPTION
## Hide the cookie banner after login

Normally we hide the cookie banner after the start page, but we've
_techincally_ got 2 'start' pages, `/start` and `/login`. This makes the
login controller hide the cookie banner too.

Issue: none