### PR TITLE
bugfix/login-link-default-port

### DIFF
--- a/src/config/app.js
+++ b/src/config/app.js
@@ -3,7 +3,7 @@ const config = Object.freeze({
   port: process.env.TRR_PORT || '3010',
   sessionSecret: process.env.TRR_SESSION_SECRET || 'override_this_value',
   apiEndpoint: process.env.TR_API_URL || 'http://localhost:3001/trap-registration-api/v1',
-  hostPrefix: process.env.TRR_HOST_PREFIX || `http://localhost:${process.env.TRR_PORT}`,
+  hostPrefix: process.env.TRR_HOST_PREFIX || `http://localhost:${process.env.TRR_PORT || 3010}`,
   pathPrefix: process.env.TRR_PATH_PREFIX ? `/${process.env.TRR_PATH_PREFIX}` : '/trap-registration-return',
   cookiePrefix: process.env.COOKIE_PREFIX || '__Secure'
 });


### PR DESCRIPTION
## Set a default port for the generated login links

If not explicitly set via env-vars, the port for links was being set to undefined. This is now set to a sensible default.

Issue: none