### PR TITLE
bugfix/schedule-1-labels

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,8 @@ import app from './app.js';
 app.listen(config.port, () => {
   console.log(`Server listening on http://localhost:${config.port}${config.pathPrefix}.`);
   if (process.env.TRR_TEST) {
-    console.log(`Log in with http://localhost:${config.port}${config.pathPrefix}/login?token=${counterpart100yearToken}`);
+    console.log(
+      `Log in with http://localhost:${config.port}${config.pathPrefix}/login?token=${counterpart100yearToken}`
+    );
   }
 });

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@
 
 // Load the config.
 import config from './config/app.js';
+import {counterpart100yearToken} from './config/http-request.js';
 
 // Load the app.
 import app from './app.js';
@@ -9,4 +10,7 @@ import app from './app.js';
 // Run it.
 app.listen(config.port, () => {
   console.log(`Server listening on http://localhost:${config.port}${config.pathPrefix}.`);
+  if (process.env.TRR_TEST) {
+    console.log(`Log in with http://localhost:${config.port}${config.pathPrefix}/login?token=${counterpart100yearToken}`);
+  }
 });

--- a/src/views/details.njk
+++ b/src/views/details.njk
@@ -134,7 +134,7 @@
         items: [
           {
             value: "schedule1Birds",
-            text: "A Schedule 1 bird",
+            text: "A Raptor or Schedule 1 Bird",
             checked: model.currentSpeciesCaughtOption === "schedule1Birds",
             conditional: {
               html: scheduleHtml
@@ -142,7 +142,7 @@
           },
           {
             value: "otherSpecies",
-            text: "Animal or Non-Schedule 1 bird",
+            text: "An Animal or Bird not listed above",
             checked: model.currentSpeciesCaughtOption === "otherSpecies",
             conditional: {
               html: otherHtml


### PR DESCRIPTION
## Correct the 'schedule 1' labels …

_Technically_, the list of birds we're using is the schedule 1 list plus the raptors, so for 'correctness', we're labelling it such. I've also included a little 'nicety' for the developers. Now when you go to launch the app in `TRR_TEST` mode, it will print the login link with the token to the console.

Issue: Scottish-Natural-Heritage/Licensing#549
Issue: Scottish-Natural-Heritage/Licensing#550