### PR TITLE
changed the spelling of license to licence - Scottish-Natural-Heritag…

### DIFF
--- a/src/views/start.njk
+++ b/src/views/start.njk
@@ -16,7 +16,7 @@
         <li>a Larsen pod trap</li>
       </ul>
       <p class="govuk-body">
-        Under NatureScot's General Licenses:
+        Under NatureScot's General licences:
       </p>
       <ul class="govuk-list govuk-list--bullet">
         <li>
@@ -29,7 +29,7 @@
         </li>
       </ul>
       <p class="govuk-body">
-        Please use this service to provide your annual license return.
+        Please use this service to provide your annual licence return.
       </p>
       <p class="govuk-body">
         Providing your return takes around 5 minutes.


### PR DESCRIPTION
…e/Licensing#658

Changed two spelling mistakes. Scottish-Natural-Heritage/Licensing#658