### PR TITLE
Add some HTML content to submitted-success page. Issue Licensing 659

### DIFF
--- a/src/views/submitted-return-success.njk
+++ b/src/views/submitted-return-success.njk
@@ -1,8 +1,17 @@
 {% extends "_base.njk" %}
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+
 {% block content %}
+
   {{ govukPanel({
         titleText: "You have submitted a return"
       }) }}
+
+  <p class="govuk-body">We have sent you a confirmation email</p>
+
+  <h1 class="govuk-heading-m">What happens next</h1>
+
+  <p class="govuk-body">We will contact you if we have any questions.</p>
+
 {% endblock %}


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/659.

Adds some HTML content to the submitted-return-success page.

