### PR TITLE
Correct missing letter e from mail on verification-success page

### DIFF
--- a/src/views/verification-success.njk
+++ b/src/views/verification-success.njk
@@ -7,7 +7,7 @@
 
   {{ govukPanel({
     titleText: "You have requested a secure link to continue your return",
-    html: "Check your mail<br>"
+    html: "Check your email<br>"
   }) }}
 
   <h1 class="govuk-heading-m">What happens next</h1>


### PR DESCRIPTION
UAT feedback on https://github.com/Scottish-Natural-Heritage/Licensing/issues/1153

Changes `mail` to `email` on the verification-success page.