### PR TITLE
feature/add-uuid-to-return-post

### DIFF
--- a/src/controllers/check-answers-no-meat-baits.js
+++ b/src/controllers/check-answers-no-meat-baits.js
@@ -28,18 +28,25 @@ const checkAnswersNoMeatBaitsController = async (request) => {
     nonTargetSpeciesCaught: request.session.detailsList ? request.session.detailsList : []
   };
 
+  // Get the UUID for the request from session.
+  const uuid = request.session.uuid;
+
   // And send the return data to the API.
   try {
     // Allocate a new return.
     const newReturnResponse = await axios.post(
-      config.apiEndpoint + '/registrations/' + request.session.loggedInRegNo + '/return'
+      config.apiEndpoint + '/registrations/' + request.session.loggedInRegNo + '/return',
+      {uuid}
     );
 
     // Determine where the back-end saved it.
     const newReturnUrl = newReturnResponse.headers.location;
 
-    // Post the return's data to the API.
-    await axios.put(newReturnUrl, newReturn);
+    // Post the return's data to the API, if we have a URL. No URL means we've already
+    // received this request and UUID.
+    if (newReturnUrl) {
+      await axios.put(newReturnUrl, newReturn);
+    }
   } catch (error) {
     console.log('Error creating new return:' + error);
     request.session.apiError = true;

--- a/src/controllers/check-answers-no-meat-baits.js
+++ b/src/controllers/check-answers-no-meat-baits.js
@@ -29,7 +29,7 @@ const checkAnswersNoMeatBaitsController = async (request) => {
   };
 
   // Get the UUID for the request from session.
-  const uuid = request.session.uuid;
+  const {uuid} = request.session;
 
   // And send the return data to the API.
   try {

--- a/src/controllers/check-answers-no-non-target.js
+++ b/src/controllers/check-answers-no-non-target.js
@@ -31,7 +31,7 @@ const checkAnswersNoNonTargetController = async (request) => {
   };
 
   // Get the UUID for the request from session.
-  const uuid = request.session.uuid;
+  const {uuid} = request.session;
 
   // And send the return data to the API.
   try {

--- a/src/controllers/check-answers-no-non-target.js
+++ b/src/controllers/check-answers-no-non-target.js
@@ -30,18 +30,25 @@ const checkAnswersNoNonTargetController = async (request) => {
     nonTargetSpeciesCaught: request.session.detailsList ? request.session.detailsList : []
   };
 
+  // Get the UUID for the request from session.
+  const uuid = request.session.uuid;
+
   // And send the return data to the API.
   try {
     // Allocate a new return.
     const newReturnResponse = await axios.post(
-      config.apiEndpoint + '/registrations/' + request.session.loggedInRegNo + '/return'
+      config.apiEndpoint + '/registrations/' + request.session.loggedInRegNo + '/return',
+      {uuid}
     );
 
     // Determine where the back-end saved it.
     const newReturnUrl = newReturnResponse.headers.location;
 
-    // Post the return's data to the API.
-    await axios.put(newReturnUrl, newReturn);
+    // Post the return's data to the API, if we have a URL. No URL means we've already
+    // received this request and UUID.
+    if (newReturnUrl) {
+      await axios.put(newReturnUrl, newReturn);
+    }
   } catch (error) {
     console.log('Error creating new return:' + error);
     request.session.apiError = true;

--- a/src/controllers/check-answers-non-target-species.js
+++ b/src/controllers/check-answers-non-target-species.js
@@ -31,7 +31,7 @@ const checkAnswersNonTargetSpeciesController = async (request) => {
   };
 
   // Get the UUID for the request from session.
-  const uuid = request.session.uuid;
+  const {uuid} = request.session;
 
   // And send the return data to the API.
   try {

--- a/src/controllers/check-answers-non-target-species.js
+++ b/src/controllers/check-answers-non-target-species.js
@@ -30,18 +30,25 @@ const checkAnswersNonTargetSpeciesController = async (request) => {
     nonTargetSpeciesCaught: request.session.detailsList ? request.session.detailsList : []
   };
 
+  // Get the UUID for the request from session.
+  const uuid = request.session.uuid;
+
   // And send the return data to the API.
   try {
     // Allocate a new return.
     const newReturnResponse = await axios.post(
-      config.apiEndpoint + '/registrations/' + request.session.loggedInRegNo + '/return'
+      config.apiEndpoint + '/registrations/' + request.session.loggedInRegNo + '/return',
+      {uuid}
     );
 
     // Determine where the back-end saved it.
     const newReturnUrl = newReturnResponse.headers.location;
 
-    // Post the return's data to the API.
-    await axios.put(newReturnUrl, newReturn);
+    // Post the return's data to the API, if we have a URL. No URL means we've already
+    // received this request and UUID.
+    if (newReturnUrl) {
+      await axios.put(newReturnUrl, newReturn);
+    }
   } catch (error) {
     console.log('Error creating new return:' + error);
     request.session.apiError = true;

--- a/src/controllers/meat-baits-in-traps.js
+++ b/src/controllers/meat-baits-in-traps.js
@@ -1,6 +1,10 @@
+import {randomUUID} from 'node:crypto';
 import {ReturnState} from './_base.js';
 
 const meatBaitInTrapsController = (request) => {
+  // To mitigate the risk of replay attack we generate a UUID and save to session.
+  request.session.uuid = randomUUID();
+
   // Did the user tell us they have used meat baits.
   if (request.body.meatBaitsUsed === 'yes') {
     // Then we don't have any errors. This clears any previous errors.


### PR DESCRIPTION
Adds a UUID to POSTed requests to allow us to silently drop any requests we've already received. Hopefully mitigates against possible replay attack.

Part of issue https://github.com/Scottish-Natural-Heritage/Deer-Online-Services/issues/971.