### PR TITLE
feature/set-secure-cookie-attribute

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -45,6 +45,9 @@ const sessionDuration = 20.1 * 60 * 60 * 1000;
 
 app.set('trust proxy', 1); // Trust first proxy
 
+// Disabling as makes the code's intention more obvious.
+/* eslint-disable no-unneeded-ternary */
+
 app.use(
   session({
     // Using the __Secure- prefix to protect our cookies as per
@@ -55,9 +58,10 @@ app.use(
       maxAge: sessionDuration,
       path: `${config.pathPrefix}/`,
       httpOnly: true,
-      // We're re-writing all cookies to be secure on the proxy, so between here
-      // and there it doesn't need to be.
-      secure: false
+      // We need to set the secure attribute to true as Caddy doesn't
+      // currently rewrite the attribute for us in the way Nginx did.
+      // If we're running tests don't set it as it'll break Cypress.
+      secure: process.env.TRR_TEST ? false : true
     },
     store: new MemoryStore({
       checkPeriod: sessionDuration
@@ -67,6 +71,8 @@ app.use(
     saveUninitialized: false
   })
 );
+
+/* eslint-enable no-unneeded-ternary */
 
 app.use(
   `${config.pathPrefix}/dist`,

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import {fileURLToPath} from 'node:url';
 import path from 'node:path';
+import process from 'node:process';
 import express from 'express';
 import morgan from 'morgan';
 import nunjucks from 'nunjucks';


### PR DESCRIPTION
Sets the secure attribute on a cookie. Needed as part of the work to replace Nginx with Caddy, issue https://github.com/Scottish-Natural-Heritage/Deer-Online-Services/issues/976.