### PR TITLE
feature/add-stricter-character-filtering

### DIFF
--- a/cypress/integration/011-details-list-and-details.js
+++ b/cypress/integration/011-details-list-and-details.js
@@ -164,4 +164,31 @@ describe('details page ', () => {
     cy.get('#main-content form button.naturescot-forward-button').click();
     cy.url().should('include', '/check-answers-non-target-species');
   });
+
+  it('forbidden characters on some inputs generate errors', () => {
+    cy.visit('/details');
+
+    cy.get('input[type="text"]#current-grid-reference').type('NO 08529 29128', {delay: 1});
+    cy.get('#main-content form input[type="radio"][value="otherSpecies"]').click();
+    cy.get('input[type="text"]#current-other-species-caught').type(
+      '<a href="https://duckduckgo.com">FakeNastyLink</a>',
+      {delay: 1}
+    );
+    cy.get('input[type="text"]#current-number-caught').type('3', {delay: 1});
+    cy.get('#main-content form input[type="radio"][value="Larsen pod"]').click();
+    cy.get('textarea#current-comment').type('<a href="https://duckduckgo.com">FakeNastyLink</a>', {delay: 1});
+
+    cy.get('#main-content form button.naturescot-forward-button').click();
+    cy.url().should('include', '/details');
+
+    cy.get('.govuk-error-summary ul li a')
+      .should(
+        'contain',
+        'Name of the non-target species caught must only include letters a to z, and special characters such as hyphens, spaces and apostrophes'
+      )
+      .and(
+        'contain',
+        'More detail must only include letters a to z, and special characters such as hyphens, spaces and apostrophes'
+      );
+  });
 });

--- a/src/controllers/details.js
+++ b/src/controllers/details.js
@@ -145,7 +145,9 @@ const detailsController = (request) => {
     request.session.currentSpeciesCaughtError ||
     request.session.currentOtherSpeciesCaughtError ||
     request.session.currentNumberCaughtError ||
-    request.session.currentTrapTypeError || request.session.invalidCharsOtherSpecies || request.session.invalidCharsComment;
+    request.session.currentTrapTypeError ||
+    request.session.invalidCharsOtherSpecies ||
+    request.session.invalidCharsComment;
 
   if (request.session.detailsError) {
     // Don't return the 'formatted' one here, just send back the original one. It's too confusing otherwise.

--- a/src/controllers/details.js
+++ b/src/controllers/details.js
@@ -1,3 +1,4 @@
+import validation from '../utils/validation.js';
 import {ReturnState} from './_base.js';
 
 const validSpecies = (species, speciesArray) => {
@@ -106,6 +107,8 @@ const detailsController = (request) => {
   request.session.currentNumberCaughtError = false;
   request.session.currentTrapTypeError = false;
   request.session.detailsError = false;
+  request.session.invalidCharsOtherSpecies = false;
+  request.session.invalidCharsComment = false;
 
   request.session.currentGridReferenceError = !validGridReference(request.body.currentGridReference);
   request.session.currentSpeciesCaughtOptionError = !request.body.currentSpeciesCaughtOption;
@@ -126,13 +129,23 @@ const detailsController = (request) => {
   request.session.currentNumberCaughtError = !validNumber(request.body.currentNumberCaught);
   request.session.currentTrapTypeError = !request.body.currentTrapType;
 
+  request.session.invalidCharsOtherSpecies = validation.hasInvalidCharacters(
+    request.body.currentOtherSpeciesCaught,
+    validation.invalidCharacters
+  );
+
+  request.session.invalidCharsComment = validation.hasInvalidCharacters(
+    request.body.currentComment,
+    validation.invalidCharacters
+  );
+
   request.session.detailsError =
     request.session.currentGridReferenceError ||
     request.session.currentSpeciesCaughtOptionError ||
     request.session.currentSpeciesCaughtError ||
     request.session.currentOtherSpeciesCaughtError ||
     request.session.currentNumberCaughtError ||
-    request.session.currentTrapTypeError;
+    request.session.currentTrapTypeError || request.session.invalidCharsOtherSpecies || request.session.invalidCharsComment;
 
   if (request.session.detailsError) {
     // Don't return the 'formatted' one here, just send back the original one. It's too confusing otherwise.

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,31 @@
+// A list of characters we do not allow the user to supply as input.
+const invalidCharacters = ['<', '>', '%', '/', '#', ':', '{', '}', '[', ']', '+', '=', '|', '*', '&'];
+
+/**
+ * Checks the supplied user input against an array of forbidden
+ * characters and returns true if the input contains any forbidden
+ * characters or else returns false if no forbidden characters or is
+ * `undefined`.
+ *
+ * @param {string | undefined} userInput The input to check for forbidden characters.
+ * @param {string[]} invalidCharacters An array of characters that are not
+ * permitted as input.
+ * @returns {boolean} Returns true if the supplied string contains any
+ * forbidden characters, else returns false if no forbidden characters or input
+ * is `undefined`.
+ */
+const hasInvalidCharacters = (userInput, invalidCharacters) => {
+  if (userInput) {
+    for (const char of invalidCharacters) {
+      if (userInput.includes(char)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const validationUtils = {hasInvalidCharacters, invalidCharacters};
+
+export default validationUtils;

--- a/src/views/details.njk
+++ b/src/views/details.njk
@@ -1,5 +1,13 @@
 {% extends "_base.njk" %}
 
+{% set otherSpeciesCaughtErrors %}
+  {% if model.currentOtherSpeciesCaughtError %}
+    Enter the name of the non-target species caught
+    {% elif model.invalidCharsOtherSpecies %}
+    Name of the non-target species caught must only include letters a to z, and special characters such as hyphens, spaces and apostrophes
+  {% endif %}
+{% endset -%}
+
 {% block head %}
   {{ super() }}
   <link rel="stylesheet" href="{{pathPrefix}}/accessible-autocomplete/accessible-autocomplete.min.css">
@@ -44,7 +52,15 @@
         {
           text: "Select the trap type that was used",
           href: "#current-trap-type-error"
-        } if model.currentTrapTypeError
+        } if model.currentTrapTypeError,
+        {
+          text: "Name of the non-target species caught must only include letters a to z, and special characters such as hyphens, spaces and apostrophes",
+          href: "#current-other-species-caught-error"
+        } if model.invalidCharsOtherSpecies,
+        {
+          text: "More detail must only include letters a to z, and special characters such as hyphens, spaces and apostrophes",
+          href: "#current-comment-error"
+        } if model.invalidCharsComment
       ]
     }) }}
   {% endif %}
@@ -80,8 +96,8 @@
       name: "currentOtherSpeciesCaught",
       value: model.currentOtherSpeciesCaught,
       errorMessage: {
-        text: "Enter the name of the non-target species caught"
-      } if model.currentOtherSpeciesCaughtError,
+        html: otherSpeciesCaughtErrors
+      } if model.currentOtherSpeciesCaughtError or model.invalidCharsOtherSpecies,
       attributes: {
         spellcheck: "false"
       }
@@ -214,7 +230,10 @@
             value: model.currentComment,
             hint: {
               text: "Provide any additional details e.g. same bird caught twice, or released unharmed"
-            }
+            },
+            errorMessage: {
+              text: "More detail must only include letters a to z, and special characters such as hyphens, spaces and apostrophes"
+            } if model.invalidCharsComment
           }) }}
 
         {% endcall %}


### PR DESCRIPTION
Two fields, the free text input to get a non-target species name if not in the drop-down, and the more detail text area, allowed "bad" characters as input. This PR adds validation to those fields.

Issue https://github.com/Scottish-Natural-Heritage/Deer-Online-Services/issues/974.